### PR TITLE
feat: serve demo UI via FastAPI with CORS and healthz

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ venv/
 .dist/
 .cache/
 .pytest_cache/
+# keep .artifacts for live demo

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Exclude git metadata and caches
+.git
+.github
+.vscode
+.idea
+
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+.venv/
+venv/
+.env
+.env.*
+.dist/
+.cache/
+.pytest_cache/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,18 @@
+# Use same rules as .dockerignore to control Cloud Build context
+.git
+.github
+.vscode
+.idea
+
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+.venv/
+venv/
+.env
+.env.*
+.dist/
+.cache/
+.pytest_cache/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -16,3 +16,4 @@ venv/
 .dist/
 .cache/
 .pytest_cache/
+# keep .artifacts for live demo

--- a/README.md
+++ b/README.md
@@ -160,13 +160,14 @@ Keep them short — fast to embed, cheap to store.
 
 ### Live Demo UI (same Cloud Run service)
 
-1. Create vectors + catalog locally (must exist before build):
+1. Authenticate and prepare vectors:
    ```bash
-   PROJECT_ID=<PROJECT_ID> LOCATION=us-central1 python -m app.retriever.upsert_vector
+   gcloud auth application-default login
+   PROJECT_ID=<PROJECT_ID> LOCATION=us-central1 python -m app.retriever.upsert_vector  # prints deployed_index_id
    ls -l .artifacts/catalog.json
    ```
 
-Build & deploy the agent (UI + API together):
+2. Build & deploy the agent (UI + API together):
 
 ```bash
 gcloud builds submit \
@@ -181,13 +182,20 @@ gcloud run deploy agentops-mock \
   --set-env-vars PROJECT_ID=<PROJECT_ID>,LOCATION=us-central1,INDEX_DISPLAY_NAME=agentops-mock-index,ENDPOINT_DISPLAY_NAME=agentops-mock-endpoint
 ```
 
-Open the UI:
+3. Open the UI:
 
 ```
-https://<cloud-run-host>/ui/index.html
+$AGENT_URL/ui/index.html
 ```
 
 (Optionally point at another agent with ?agent=https://other-host)
+
+#### Troubleshooting
+
+- `ALREADY_EXISTS` deployedIndexId → script now auto-suffixes; re-run upsert.
+- `StreamUpdate not enabled` → index is always created with `STREAM_UPDATE`.
+- `Incorrect dimensionality` → index dimension is derived from the embedding and is part of the display name (e.g., `-768d`).
+- `Catalog not found` → run upsert locally, then rebuild & redeploy.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,37 @@ Keep them short — fast to embed, cheap to store.
 4. Run `python -m app.retriever.upsert_vector` locally to create embeddings + index.
 5. Deploy **agentops-mock** → Cloud Run with env vars pointing to MCP services and Vector Search settings.
 
+### Live Demo UI (same Cloud Run service)
+
+1. Create vectors + catalog locally (must exist before build):
+   ```bash
+   PROJECT_ID=<PROJECT_ID> LOCATION=us-central1 python -m app.retriever.upsert_vector
+   ls -l .artifacts/catalog.json
+   ```
+
+Build & deploy the agent (UI + API together):
+
+```bash
+gcloud builds submit \
+  --config infra/cloudbuild.agent.yaml \
+  --substitutions=_IMAGE=gcr.io/<PROJECT_ID>/agentops-mock .
+
+gcloud run deploy agentops-mock \
+  --image gcr.io/<PROJECT_ID>/agentops-mock \
+  --allow-unauthenticated \
+  --region us-central1 \
+  --port 8080 \
+  --set-env-vars PROJECT_ID=<PROJECT_ID>,LOCATION=us-central1,INDEX_DISPLAY_NAME=agentops-mock-index,ENDPOINT_DISPLAY_NAME=agentops-mock-endpoint
+```
+
+Open the UI:
+
+```
+https://<cloud-run-host>/ui/index.html
+```
+
+(Optionally point at another agent with ?agent=https://other-host)
+
 ---
 
 ## Try It

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ app = FastAPI(title="agentops-mock")
 
 # Serve the UI from /ui
 ui_dir = os.path.join(os.path.dirname(__file__), "web")
-app.mount("/ui", StaticFiles(directory=ui_dir), name="ui")
+app.mount("/ui", StaticFiles(directory=ui_dir, html=True), name="ui")
 
 app.add_middleware(
     CORSMiddleware,

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
 import os
 import requests
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
 from .retriever.search import search_topk
@@ -9,6 +11,22 @@ TASKS_MCP_BASE = os.getenv("TASKS_MCP_BASE")
 CLAIMS_MCP_BASE = os.getenv("CLAIMS_MCP_BASE")
 
 app = FastAPI(title="agentops-mock")
+
+# Serve the UI from /ui
+ui_dir = os.path.join(os.path.dirname(__file__), "web")
+app.mount("/ui", StaticFiles(directory=ui_dir), name="ui")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/healthz")
+def healthz():
+    return {"ok": True}
 
 
 class ChatRequest(BaseModel):

--- a/app/retriever/upsert_vector.py
+++ b/app/retriever/upsert_vector.py
@@ -82,7 +82,7 @@ def _ensure_endpoint_and_deploy(index_name: str, deployed_index_id_base: str) ->
         message = str(e)
         if "already exists a DeployedIndex with same ID" in message or "ALREADY_EXISTS" in message:
             short = uuid.uuid4().hex[:6]
-            deployed_id = f"{deployed_index_id_base}-{short}"
+            deployed_id = f"{deployed_index_id_base}_{short}"
             idx_obj = aiplatform.MatchingEngineIndex(index_name)
             endpoint.deploy_index(index=idx_obj, deployed_index_id=deployed_id)
             time.sleep(10)
@@ -105,7 +105,7 @@ def run_upsert() -> Dict:
     vectors = _embed_texts([r["text"] for r in records])
     embed_dim = len(vectors[0])
     index_display_name = f"{INDEX_DISPLAY_NAME_BASE}-{embed_dim}d"
-    deployed_index_id_base = f"agentops-{embed_dim}d"
+    deployed_index_id_base = f"agentops_{embed_dim}d"
 
     # Ensure index + endpoint deploy
     index_name = _ensure_index(embed_dim, index_display_name)

--- a/app/retriever/upsert_vector.py
+++ b/app/retriever/upsert_vector.py
@@ -1,74 +1,20 @@
-import json
-import os
-import time
-import uuid
-from typing import List, Dict
+import json, os, time, uuid
+from typing import List, Dict, Tuple
 
 from google.cloud import aiplatform
+from google.cloud import aiplatform_v1
 from vertexai import init as vertex_init
 from vertexai.preview.language_models import TextEmbeddingModel
 
 from .chunk import load_docs, chunk_text
 
-# Env
 PROJECT_ID = os.getenv("PROJECT_ID")
 LOCATION = os.getenv("LOCATION", "us-central1")
-INDEX_DISPLAY_NAME = os.getenv("INDEX_DISPLAY_NAME", "agentops-mock-index")
-ENDPOINT_DISPLAY_NAME = os.getenv("ENDPOINT_DISPLAY_NAME", "agentops-mock-endpoint")
-DOCS_DIR = os.getenv("DOCS_DIR", "mocks/data/docs")
 
-EMBED_MODEL = os.getenv("EMBED_MODEL", "text-embedding-004")
-DIMENSIONS = int(os.getenv("EMBED_DIM", "3072"))  # text-embedding-004 outputs 3072 dims
-
-
-def _ensure_index() -> str:
-    """Create or reuse a small Tree-AH index with required params."""
-    aiplatform.init(project=PROJECT_ID, location=LOCATION)
-
-    # Reuse if exists
-    for idx in aiplatform.MatchingEngineIndex.list():
-        if idx.display_name == INDEX_DISPLAY_NAME:
-            return idx.resource_name
-
-    # Create a new Tree-AH index (explicitly set approximate_neighbors_count)
-    index = aiplatform.MatchingEngineIndex.create_tree_ah_index(
-        display_name=INDEX_DISPLAY_NAME,
-        dimensions=DIMENSIONS,
-        distance_measure_type="COSINE_DISTANCE",
-        leaf_node_embedding_count=1000,        # tiny demo value
-        leaf_nodes_to_search_percent=7,        # search % for recall/speed tradeoff
-        approximate_neighbors_count=10,        # REQUIRED for Tree-AH
-        description="AgentOps mock Tree-AH index",
-    )
-    index.wait()
-    return index.resource_name
-
-
-def _ensure_endpoint(index_name: str) -> str:
-    aiplatform.init(project=PROJECT_ID, location=LOCATION)
-
-    # Reuse endpoint if present
-    for ep in aiplatform.MatchingEngineIndexEndpoint.list():
-        if ep.display_name == ENDPOINT_DISPLAY_NAME:
-            endpoint = ep
-            break
-    else:
-        # PUBLIC endpoint for demo (no VPC needed)
-        endpoint = aiplatform.MatchingEngineIndexEndpoint.create(
-            display_name=ENDPOINT_DISPLAY_NAME,
-            description="AgentOps mock endpoint",
-            public_endpoint_enabled=True,
-        )
-        endpoint.wait()
-
-    # Deploy index if not already deployed
-    deployed = any(d.index == index_name for d in endpoint.deployed_indexes)
-    if not deployed:
-        idx_obj = aiplatform.MatchingEngineIndex(index_name)  # <-- key line
-        endpoint.deploy_index(index=idx_obj, deployed_index_id="agentops_deployed")
-        time.sleep(15)
-
-    return endpoint.resource_name
+INDEX_DISPLAY_NAME_BASE = os.getenv("INDEX_DISPLAY_NAME", "agentops-mock-index")
+ENDPOINT_DISPLAY_NAME   = os.getenv("ENDPOINT_DISPLAY_NAME", "agentops-mock-endpoint")
+DOCS_DIR                = os.getenv("DOCS_DIR", "mocks/data/docs")
+EMBED_MODEL             = os.getenv("EMBED_MODEL", "text-embedding-004")
 
 def _embed_texts(texts: List[str]) -> List[List[float]]:
     vertex_init(project=PROJECT_ID, location=LOCATION)
@@ -81,54 +27,116 @@ def _embed_texts(texts: List[str]) -> List[List[float]]:
         vecs.extend(e.values for e in embeddings)
     return vecs
 
+def _ensure_index(dimensions: int, display_name: str) -> str:
+    aiplatform.init(project=PROJECT_ID, location=LOCATION)
+    for idx in aiplatform.MatchingEngineIndex.list():
+        if idx.display_name == display_name:
+            return idx.resource_name
+    index = aiplatform.MatchingEngineIndex.create_tree_ah_index(
+        display_name=display_name,
+        dimensions=dimensions,
+        distance_measure_type="COSINE_DISTANCE",
+        leaf_node_embedding_count=1000,
+        leaf_nodes_to_search_percent=7,
+        approximate_neighbors_count=10,
+        index_update_method="STREAM_UPDATE",
+        description=f"Tree-AH ({dimensions}d, STREAM_UPDATE)",
+    )
+    index.wait()
+    return index.resource_name
+
+def _ensure_endpoint_and_deploy(index_name: str, deployed_index_id_base: str) -> Tuple[str, str]:
+    """
+    Returns (endpoint_resource_name, deployed_index_id_in_use).
+    Handles conflicts by generating a unique deployed_index_id when needed.
+    """
+    aiplatform.init(project=PROJECT_ID, location=LOCATION)
+    # Find or create public endpoint
+    endpoint = None
+    for ep in aiplatform.MatchingEngineIndexEndpoint.list():
+        if ep.display_name == ENDPOINT_DISPLAY_NAME:
+            endpoint = ep
+            break
+    if endpoint is None:
+        endpoint = aiplatform.MatchingEngineIndexEndpoint.create(
+            display_name=ENDPOINT_DISPLAY_NAME,
+            description="Public endpoint for AgentOps demo",
+            public_endpoint_enabled=True,
+        )
+        endpoint.wait()
+
+    # If this index already deployed → reuse
+    for d in endpoint.deployed_indexes:
+        if d.index == index_name:
+            # Already deployed; return existing deployedIndexId
+            return endpoint.resource_name, d.id
+
+    # Otherwise, try deploy with base ID; if conflicting, add a short suffix
+    deployed_id = deployed_index_id_base
+    try:
+        idx_obj = aiplatform.MatchingEngineIndex(index_name)
+        endpoint.deploy_index(index=idx_obj, deployed_index_id=deployed_id)
+        time.sleep(10)
+        return endpoint.resource_name, deployed_id
+    except Exception as e:
+        message = str(e)
+        if "already exists a DeployedIndex with same ID" in message or "ALREADY_EXISTS" in message:
+            short = uuid.uuid4().hex[:6]
+            deployed_id = f"{deployed_index_id_base}-{short}"
+            idx_obj = aiplatform.MatchingEngineIndex(index_name)
+            endpoint.deploy_index(index=idx_obj, deployed_index_id=deployed_id)
+            time.sleep(10)
+            return endpoint.resource_name, deployed_id
+        raise
 
 def run_upsert() -> Dict:
     aiplatform.init(project=PROJECT_ID, location=LOCATION)
 
-    # 1) Ensure index + endpoint
-    index_name = _ensure_index()
-    endpoint_name = _ensure_endpoint(index_name)
-
-    # 2) Load & chunk docs
-    docs = load_docs(DOCS_DIR)
+    # Load & chunk docs
+    docs: List[Tuple[str, str]] = load_docs(DOCS_DIR)
     records = []
     for title, text in docs:
         for ix, ch in enumerate(chunk_text(text)):
-            records.append({
-                "id": str(uuid.uuid4()),
-                "title": title,
-                "chunk_ix": ix,
-                "text": ch,
-            })
-
+            records.append({"id": str(uuid.uuid4()), "title": title, "chunk_ix": ix, "text": ch})
     if not records:
         return {"ok": False, "reason": "no docs/chunks"}
 
-    # 3) Embed
+    # Embed first to know the true dim
     vectors = _embed_texts([r["text"] for r in records])
+    embed_dim = len(vectors[0])
+    index_display_name = f"{INDEX_DISPLAY_NAME_BASE}-{embed_dim}d"
+    deployed_index_id_base = f"agentops-{embed_dim}d"
 
-    # 4) Upsert datapoints
-    index = aiplatform.MatchingEngineIndex(index_name)
-    dps = []
-    for r, v in zip(records, vectors):
-        dp = aiplatform.datapoint.Datapoint(
-            datapoint_id=r["id"],
-            feature_vector=v,
-            restricts=[],
-            crowding_tag=None,
-        )
-        dps.append(dp)
+    # Ensure index + endpoint deploy
+    index_name = _ensure_index(embed_dim, index_display_name)
+    endpoint_name, deployed_index_id = _ensure_endpoint_and_deploy(index_name, deployed_index_id_base)
 
-    index.upsert_datapoints(datapoints=dps)
+    # Upsert via GAPIC
+    idx_client = aiplatform_v1.IndexServiceClient(
+        client_options={"api_endpoint": f"{LOCATION}-aiplatform.googleapis.com"}
+    )
+    datapoints = [
+        aiplatform_v1.IndexDatapoint(datapoint_id=r["id"], feature_vector=v)
+        for r, v in zip(records, vectors)
+    ]
+    req = aiplatform_v1.UpsertDatapointsRequest(index=index_name, datapoints=datapoints)
+    idx_client.upsert_datapoints(request=req)
 
-    # 5) Save catalog mapping locally
+    # Write catalog
     os.makedirs(".artifacts", exist_ok=True)
     catalog = {r["id"]: {"title": r["title"], "chunk_ix": r["chunk_ix"], "text": r["text"]} for r in records}
     with open(".artifacts/catalog.json", "w", encoding="utf-8") as f:
         json.dump(catalog, f, ensure_ascii=False, indent=2)
 
-    return {"ok": True, "index": index_name, "endpoint": endpoint_name, "count": len(records)}
-
+    return {
+        "ok": True,
+        "index": index_name,
+        "endpoint": endpoint_name,
+        "count": len(records),
+        "dim": embed_dim,
+        "index_display_name": index_display_name,
+        "deployed_index_id": deployed_index_id,
+    }
 
 if __name__ == "__main__":
     out = run_upsert()

--- a/app/web/index.html
+++ b/app/web/index.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>AgentOps Mock – Live Demo</title>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, Arial; margin: 24px; max-width: 960px; }
+    textarea { width: 100%; height: 90px; }
+    pre { background: #f6f8fa; padding: 12px; overflow: auto; }
+    .row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+    .btn { padding: 8px 12px; border: 1px solid #ccc; background: #fff; cursor: pointer; }
+    .btn:hover { background: #f1f5f9; }
+    .cols { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    input[type=text] { width: 100%; }
+  </style>
+</head>
+<body>
+  <h1>AgentOps Mock – Live Demo</h1>
+  <p>Ask a question (RAG), or use quick actions (Tasks/Claims).</p>
+
+  <label>Agent URL:
+    <input id="agentUrl" type="text" />
+  </label>
+
+  <h3>Chat (RAG)</h3>
+  <textarea id="query" placeholder="e.g., What are the key steps in our release audit checklist?"></textarea>
+  <div class="row">
+    <button class="btn" id="askBtn">Ask</button>
+    <span id="status"></span>
+  </div>
+
+  <div class="cols">
+    <div>
+      <h4>Answer</h4>
+      <pre id="answer"></pre>
+    </div>
+    <div>
+      <h4>Contexts</h4>
+      <pre id="contexts"></pre>
+    </div>
+  </div>
+
+  <h3>Quick Actions</h3>
+  <div class="row">
+    <button class="btn" data-q='Add a task: Prepare enablement deck for SI workshop due 2025-09-09'>Add Task</button>
+    <button class="btn" data-q='List my tasks'>List Tasks</button>
+    <button class="btn" data-q='What is the claims service status?'>Claims Status</button>
+    <button class="btn" data-q='Create FNOL for external ref 734206245 with 2 docs'>Create FNOL</button>
+  </div>
+
+  <h4>Raw Response</h4>
+  <pre id="raw"></pre>
+
+  <script>
+    const agentInput = document.getElementById('agentUrl');
+    const q = document.getElementById('query');
+    const askBtn = document.getElementById('askBtn');
+    const answer = document.getElementById('answer');
+    const contexts = document.getElementById('contexts');
+    const raw = document.getElementById('raw');
+    const status = document.getElementById('status');
+
+    // Default to same-origin (UI + API on one Cloud Run service)
+    agentInput.value = location.origin;
+
+    // Allow override via ?agent=<url>
+    const params = new URLSearchParams(location.search);
+    if (params.get('agent')) agentInput.value = params.get('agent');
+
+    async function callAgent(text) {
+      status.textContent = 'Calling...';
+      answer.textContent = '';
+      contexts.textContent = '';
+      raw.textContent = '';
+      try {
+        const base = agentInput.value.replace(/\/$/, '');
+        const res = await fetch(base + '/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query: text })
+        });
+        const data = await res.json();
+        raw.textContent = JSON.stringify(data, null, 2);
+        answer.textContent = data.answer ?? '';
+        contexts.textContent = JSON.stringify(data.contexts ?? [], null, 2);
+        status.textContent = res.ok ? 'OK' : ('HTTP ' + res.status);
+      } catch (e) {
+        status.textContent = 'Error';
+        raw.textContent = String(e);
+      }
+    }
+
+    askBtn.onclick = () => callAgent(q.value.trim());
+    document.querySelectorAll('button[data-q]').forEach(btn => {
+      btn.onclick = () => callAgent(btn.getAttribute('data-q'));
+    });
+  </script>
+</body>
+</html>

--- a/scripts/describe_vector.sh
+++ b/scripts/describe_vector.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PROJECT_ID="${PROJECT_ID:-agentops-mock}"
+LOCATION="${LOCATION:-us-central1}"
+
+echo "== Indexes =="
+gcloud ai indexes list --region "$LOCATION"
+echo
+echo "== Endpoints =="
+gcloud ai index-endpoints list --region "$LOCATION"
+echo
+echo "Tip: describe an endpoint:"
+echo "gcloud ai index-endpoints describe <ID> --region $LOCATION | sed -n '1,200p'"

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="${REGION:-us-central1}"
+SERVICE="${SERVICE:-agentops-mock}"
+
+AGENT_URL="$(gcloud run services describe "$SERVICE" --region "$REGION" --format='value(status.url)')"
+echo "AGENT_URL=$AGENT_URL"
+
+echo "== /healthz =="
+curl -fsS "$AGENT_URL/healthz" && echo
+
+echo "== /chat (RAG) =="
+curl -fsS -X POST "$AGENT_URL/chat" -H 'Content-Type: application/json' \
+  -d '{"query":"What are the key steps in our release audit checklist?"}' && echo
+
+echo "== UI =="
+echo "$AGENT_URL/ui/index.html"


### PR DESCRIPTION
## Summary
- add minimal static UI under `/ui` and include assets in Docker build
- enable permissive CORS and add `/healthz`
- document Cloud Run deployment with demo UI steps

## Testing
- `python -m py_compile app/main.py app/retriever/search.py`


------
https://chatgpt.com/codex/tasks/task_e_68be288a83a4832fb2f1525a7dcb7dc3